### PR TITLE
Add blog RSS feed link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="description" content="Michiel B. de Jong" />
     <link rel="author" href="http://michielbdejong.com/" />
+    <link rel="alternate" type="application/rss+xml" title="Michiel B. de Jong" href="https://github.com/michielbdejong/michielbdejong.com/commits/gh-pages/blog.atom">
     <style>
       body {background-color: #404040 }
       footer { background: url(img/bg.jpg) no-repeat center; background-size: contain; padding: 8em; border-radius: 1em }


### PR DESCRIPTION
I was looking at your website and I didn't find a way to subscribe to updates on your blog. Using this github feature is an easy way to achieve it :).

If you like it you could also add a link in the body prompting people to subscribe. But at least with this someone typing "michielbdejong.com" on their reader app will get the updates (and some browsers will show an RSS button in the navigation bar).

Reject the PR if you don't like the idea, but I think it's useful!